### PR TITLE
postgresql adapter option added

### DIFF
--- a/templates/postgresql-local.yml
+++ b/templates/postgresql-local.yml
@@ -1,5 +1,5 @@
 test:
-    adapter: postgresql
+    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
     encoding: "utf8"
     database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>

--- a/templates/postgresql.yml
+++ b/templates/postgresql.yml
@@ -1,5 +1,5 @@
 test:
-    adapter: postgresql
+    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
     encoding: "utf8"
     database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: rails-database-yml
-version: 1.0.1
+version: 1.0.2
 description: rails-database-yml step


### PR DESCRIPTION
In rare cases we need to specify postgresql adapter name that is `postgresql` by default, but, for example, for postgis-enabled databases (for geo-spatial applications) it should be `postgis`. I've add this option as `WERCKER_POSTGRESQL_ADAPTER` env variable or just `postgresql` if this variable is empty.