### PR TITLE
Support utf8mb4 and production database for assets precompile in production

### DIFF
--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,8 +1,15 @@
-test:
+base: &base
     adapter: mysql2
-    encoding: utf8
-    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    encoding: <%= ENV['WERCKER_MYSQL_ENCODING'] || 'utf8' %>
+    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %>
     username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>
     host: <%= ENV['WERCKER_MYSQL_HOST'] %>
     port: <%= ENV['WERCKER_MYSQL_PORT'] %>
+
+test:
+    <<: *base
+    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+
+production:
+    <<: *base


### PR DESCRIPTION
I want to use utf8mb4 and assets precompile with `RAILS_ENV=production` on wercker build phase
