### PR TITLE
Refactor to add ewok support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,41 @@
 # Rails database yml
 
-Generates a `config/database.yml` file with the environment information from your database service.
+Generates a `config/database.yml` file with the environment information from
+your database service.
 
-For this step you need to have a mysql or postgres. See the [services](http://devcenter.wercker.com/articles/services/) on wercker devcenter for more information about services.
+For this step you need to have a mysql or postgres. See the
+[services](http://devcenter.wercker.com/learn/wercker-yml/02_sections.html#services)
+on wercker devcenter for more information about services.
 
 # What's new
 
-- Add `postgresql-min-message` parameter
+- Add support for the ewok stack.
 
 # Options
 
-- `service` This option is not required. If set, it will load the template from the specified service; otherwise, it will infer the service from the environment.
-- `postgresql-min-message` (optinal, default: `warning`): Set the min_messages parameter in the postgresql template.
+- `service` This option is not required. If set, it will load the template from
+the specified service; otherwise, it will infer the service from the
+environment.
+- `postgresql-min-message` (optinal, default: `warning`): Set the min_messages
+parameter in the postgresql template.
+
+# Supported services
+
+Currently `wercker/postgresql` and `wercker/mysql` for the old stack are
+supported. No further configuration is required for these services.
+
+The following docker containers are supported in the new stack: `postgres` and
+`mysql`. Both have some required and recommended environment variables.
+
+The `postgresql` container requires the `POSTGRES_PASSWORD` environment variable
+to be set. The other environment variables are `POSTGRES_USER` and
+`POSTGRES_DB`. All environment variables are used in this step, or use the same
+defaults as the container.
+
+The `mysql` container requires the `MYSQL_ROOT_PASSWORD`, but this password
+won't be used by this step. Make sure you also set `MYSQL_DATABASE`,
+`MYSQL_USER` and `MYSQL_PASSWORD`. These are the environment variables that will
+be used by this step.
 
 # Example
 
@@ -41,6 +65,10 @@ test:
 ```
 
 # Changelog
+
+## 1.1.0
+
+- Add support for the ewok stack.
 
 ## 1.0.0
 

--- a/run.sh
+++ b/run.sh
@@ -1,48 +1,183 @@
-template_name=""
+#!/bin/bash
 
-if [ -z $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE ]; then
-  export WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE="warning"
-fi
+main() {
+  local database_yml_path="$PWD/config/database.yml"
 
-if [ ! -n "$WERCKER_RAILS_DATABASE_YML_SERVICE" ]; then
-  debug 'service option not specified, looking for services in the environment'
+  if [ -f "$database_yml_path" ]; then
+    debug 'config/database.yml already exists and will be overwritten'
+  fi
 
+  if [ -z "$WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE" ]; then
+    export WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE="warning"
+  fi
+
+  if [ -n "$WERCKER_RAILS_DATABASE_YML_SERVICE" ]; then
+    info "Skipping autodetection; service option set: $WERCKER_RAILS_DATABASE_YML_SERVICE"
+
+    case "$WERCKER_RAILS_DATABASE_YML_SERVICE" in
+      postgresql|postgresql-legacy)
+        generate_postgresql_legacy "$database_yml_path"
+        ;;
+      postgresql-docker)
+        generate_postgresql_docker "$database_yml_path"
+        ;;
+      postgresql-local)
+        generate_postgresql_local "$database_yml_path"
+        ;;
+      mysql|mysql-legacy)
+        generate_mysql_legacy "$database_yml_path"
+        ;;
+      mysql-docker)
+        generate_mysql_docker "$database_yml_path"
+        ;;
+      *)
+        fail 'Invalid service; currently supported: postgresql, postgresql-legacy, postgresql-docker, postgresql-local, mysql, mysql-legacy, mysql-docker'
+        ;;
+    esac
+    return
+  fi
+
+  info "Auto detecting service"
+
+  # Check if there is a linked docker postgresql instance
+  if [ -n "$POSTGRES_PORT_5432_TCP_ADDR" ]; then
+    generate_postgresql_docker "$database_yml_path"
+    return
+  fi
+
+  # Check if there is a linked docker mysql instance
+  if [ -n "$MYSQL_PORT_3306_TCP_ADDR" ]; then
+    generate_mysql_docker "$database_yml_path"
+    return
+  fi
+
+  # Check if there is a legacy postgresql box
+  if [ -n "$WERCKER_POSTGRESQL_HOST" ]; then
+    generate_postgresql_legacy "$database_yml_path"
+    return
+  fi
+
+  # Check if there is a legacy mysql box
   if [ -n "$WERCKER_MYSQL_HOST" ]; then
-    info 'mysql service found'
-    template_name="mysql"
-  elif [ -n "$WERCKER_POSTGRESQL_HOST" ]; then
-    info 'postgresql service found'
-
-
-    template_name="postgresql"
-  elif [ -n "$WERCKER_POSTGRESQL_DATABASE" ]; then
-    info 'postgresql local service found'
-    template_name="postgresql-local"
-  else
-    fail 'No compatible service defined in wercker.yml.\nSupported service are: mysql and postgresql.\n\nSee: http://devcenter.wercker.com/articles/services/'
-  fi
-else
-  debug 'service option specified, will load specified template'
-  template_name="$WERCKER_RAILS_DATABASE_YML_SERVICE"
-fi
-
-info "using template $template_name"
-template_filename="$WERCKER_STEP_ROOT/templates/$template_name.yml"
-
-if [ ! -f "$template_filename" ]; then
-  fail "no template found with name $template_name"
-else
-  config_filename="$PWD/config/database.yml"
-
-  if [ -f "$config_filename" ]; then
-    warn 'config/database.yml already exists and will be overwritten'
+    generate_mysql_legacy "$database_yml_path"
+    return
   fi
 
-  # cp -f "$template_filename" "$config_filename"
-  sed \
-    -e "s;\$WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE;$WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE;g" \
-    "$template_filename" > "$config_filename";
+  # Check if WERCKER_POSTGRESQL_DATABASE is set to create local instance (deprecated)
+  if [ -n "$WERCKER_POSTGRESQL_DATABASE" ]; then
+    generate_postgresql_local "$database_yml_path"
+    return
+  fi
 
-  info "created database.yml in config directory with content:"
-  info "$(cat "$config_filename")"
-fi
+  fail 'Unable to auto detect service; please set "service" option'
+}
+
+# generate_postgresql_docker $location
+# generate a database.yml based on docker links
+generate_postgresql_docker() {
+  local location="${1:?'location is required'}"
+
+  if [ -z "$POSTGRES_ENV_POSTGRES_PASSWORD" ]; then
+    warn "POSTGRES_PASSWORD env var for the postgres service is not set"
+  fi
+
+  info "Generating postgresql docker template"
+  tee "$location" << EOF
+test:
+    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
+    encoding: "utf8"
+    database: <%= ENV['POSTGRES_ENV_POSTGRES_DB'] || ENV['POSTGRES_ENV_POSTGRES_USER'] || 'postgres' %><%= ENV['TEST_ENV_NUMBER'] %>
+    username: <%= ENV['POSTGRES_ENV_POSTGRES_USER'] || 'postgres' %>
+    password: <%= ENV['POSTGRES_ENV_POSTGRES_PASSWORD'] %>
+    host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] %>
+    port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] %>
+    min_messages: $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE
+EOF
+}
+
+# generate_postgresql_legacy $location
+# generate a database.yml based on legacy wercker box.
+generate_postgresql_legacy() {
+  local location="${1:?'location is required'}"
+
+  info "Generating postgresql legacy template"
+  tee "$location" << EOF
+test:
+    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
+    encoding: "utf8"
+    database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>
+    password: <%= ENV['WERCKER_POSTGRESQL_PASSWORD'] %>
+    host: <%= ENV['WERCKER_POSTGRESQL_HOST'] %>
+    port: <%= ENV['WERCKER_POSTGRESQL_PORT'] %>
+    min_messages: $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE
+EOF
+}
+
+# generate_postgresql_local $location
+# generate a database.yml based on local postgresql instance (deprecated).
+generate_postgresql_local() {
+  local location="${1:?'location is required'}"
+
+  info "Generating postgresql local template"
+  warn "Local postgresql database.yml is now deprecated. Consider copying a static file, or fork this step."
+  tee "$location" << EOF
+test:
+    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
+    encoding: "utf8"
+    database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>
+    password: <%= ENV['WERCKER_POSTGRESQL_PASSWORD'] %>
+    min_messages: $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE
+EOF
+}
+
+# generate_mysql_docker $location
+# generate a database.yml based on docker links
+generate_mysql_docker() {
+  local location="${1:?'location is required'}"
+
+  if [ -z "$MYSQL_ENV_MYSQL_DATABASE" ]; then
+    warn "MYSQL_DATABASE env var for the mysql service is not set"
+  fi
+
+  if [ -z "$MYSQL_ENV_MYSQL_USER" ]; then
+    warn "MYSQL_USER env var for the mysql service is not set"
+  fi
+
+  if [ -z "$MYSQL_ENV_MYSQL_PASSWORD" ]; then
+    warn "MYSQL_PASSWORD env var for the mysql service is not set"
+  fi
+
+  info "Generating mysql docker template"
+  tee "$location" << EOF
+test:
+    adapter: mysql2
+    encoding: utf8
+    database: <%= ENV['MYSQL_ENV_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    username: <%= ENV['MYSQL_ENV_MYSQL_USER'] %>
+    password: <%= ENV['MYSQL_ENV_MYSQL_PASSWORD'] %>
+    host: <%= ENV['MYSQL_PORT_3306_TCP_ADDR'] %>
+    port: <%= ENV['MYSQL_PORT_3306_TCP_PORT'] %>
+EOF
+}
+
+# generate_mysql_legacy $location
+# generate a database.yml based on legacy wercker box.
+generate_mysql_legacy() {
+  local location="${1:?'location is required'}"
+
+  info "Generating mysql legacy template"
+  tee "$location" << EOF
+test:
+    adapter: mysql2
+    encoding: utf8
+    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
+    password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>
+    host: <%= ENV['WERCKER_MYSQL_HOST'] %>
+    port: <%= ENV['WERCKER_MYSQL_PORT'] %>
+EOF
+}
+
+main;

--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,8 +1,0 @@
-test:
-    adapter: mysql2
-    encoding: utf8
-    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
-    username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
-    password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>
-    host: <%= ENV['WERCKER_MYSQL_HOST'] %>
-    port: <%= ENV['WERCKER_MYSQL_PORT'] %>

--- a/templates/postgresql-local.yml
+++ b/templates/postgresql-local.yml
@@ -1,7 +1,0 @@
-test:
-    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
-    encoding: "utf8"
-    database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
-    username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>
-    password: <%= ENV['WERCKER_POSTGRESQL_PASSWORD'] %>
-    min_messages: $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE

--- a/templates/postgresql.yml
+++ b/templates/postgresql.yml
@@ -1,9 +1,0 @@
-test:
-    adapter: <%= ENV['WERCKER_POSTGRESQL_ADAPTER'] || 'postgresql' %>
-    encoding: "utf8"
-    database: <%= ENV['WERCKER_POSTGRESQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
-    username: <%= ENV['WERCKER_POSTGRESQL_USERNAME'] %>
-    password: <%= ENV['WERCKER_POSTGRESQL_PASSWORD'] %>
-    host: <%= ENV['WERCKER_POSTGRESQL_HOST'] %>
-    port: <%= ENV['WERCKER_POSTGRESQL_PORT'] %>
-    min_messages: $WERCKER_RAILS_DATABASE_YML_POSTGRESQL_MIN_MESSAGE

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: rails-database-yml
-version: 1.0.2
+version: 1.1.0
 description: rails-database-yml step

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,5 @@
+box: wercker/default
+
+build:
+    steps:
+        - shellcheck


### PR DESCRIPTION
The new changes will work with the official `mysql` and `postgres` container, as well as the old `wercker/mysql` and `wercker/postgresql` boxes. 

Read `Supported services` in the `README.md` for the details.

Resolves #7 